### PR TITLE
Update exemplary task manifest

### DIFF
--- a/examples/psutil-postgresql.json
+++ b/examples/psutil-postgresql.json
@@ -7,24 +7,17 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/psutil/load/load1": {},
-                "/psutil/load/load15": {}
+                "/intel/psutil/load/load1": {},
+                "/intel/psutil/load/load15": {}
             },
-            "config": {
-                "/intel/dummy": {
-                    "password": "secret",
-                    "user": "root"
-                }
-            },
+            "config": null,
             "process": [
                 {
                     "plugin_name": "passthru",
-                    "plugin_version": 1,
                     "process": null,
                     "publish": [
                         {
                             "plugin_name": "postgresql",
-                            "plugin_version": 3,
                             "config": {
                                 "hostname": "localhost",
                                 "port": 5432,


### PR DESCRIPTION
- inconsistency in names of psutil plugin
- change to taking the latest version (removed stickies to plugin version)
